### PR TITLE
SWE-232: fix cache store and add concurrency limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ First set `provider_results_cache` to add a dedicated cache instance to store pr
 
 ```ruby
 HealthMonitor.configure do |config|
-  config.provider_results_cache = ActiveSupport::Cache::MemoryStore.new
+  config.provider_results_cache = FtfStarter::Monitoring::CACHE # redis client
 end
 ```
 

--- a/lib/health_monitor/configuration.rb
+++ b/lib/health_monitor/configuration.rb
@@ -9,7 +9,8 @@ module HealthMonitor
                   :error_callback,
                   :hide_footer,
                   :path,
-                  :provider_results_cache
+                  :provider_results_cache,
+                  :concurrency_limiter
     attr_reader :providers
 
     def initialize

--- a/lib/health_monitor/version.rb
+++ b/lib/health_monitor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HealthMonitor
-  VERSION = '110.4.0'
+  VERSION = '110.4.1.alpha.1'
 end

--- a/lib/health_monitor/version.rb
+++ b/lib/health_monitor/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HealthMonitor
-  VERSION = '110.4.1.alpha.1'
+  VERSION = '110.4.1.alpha.2'
 end


### PR DESCRIPTION
**Overview** 
Currently there's a system-level "bug" for caching health check results (discovered in [slack thread](https://fundthatflip.slack.com/archives/C05APH6802D/p1695930920010869?thread_ts=1695930318.276169&cid=C05APH6802D)).
There's two causes here that result in duplicate API calls (that I see; maybe more/different issues)
   - We're only caching on the process-level using ActiveSupport::Cache::MemoryStore ([docs](https://api.rubyonrails.org/classes/ActiveSupport/Cache/MemoryStore.html)) but we run multiple processes.
   - Concurrency is not limited to 1
   
   ---

This PR addresses both but the concurrency is still a work in progress.. it's tricky and I'm still testing.. Open to any feedback/ideas ( settings/dials, using a gem, semantics etc)
- added redis cache and concurrency limiter to starter https://github.com/FundThatFlip/ftf_starter/pull/22
  - https://github.com/sidekiq/sidekiq/wiki/Ent-Rate-Limiting
- Testing with dummy providers (with variance on polling `sleep rand(2..10)`) https://github.com/FundThatFlip/signature_service/pull/302

---

Note: We call providers in the order they're listed in the `config/initializers/health_monitor.rb` 
❓❓ I wonder if we can run these external api checks in parallel - ruby is good at waiting in parallel .. seems like we're waiting on external responses. This would mean we're calling Redis in parallel - not sure what the pool size is atm - but we'd want to monitor Redis in lower envs to understand the impact

 e.g. Beta external polling
![Screenshot 2023-10-03 at 22 46 42](https://github.com/FundThatFlip/health-monitor-rails/assets/87322232/c45e5671-3cd2-4df6-a819-467f70ffc9c7)

❓❓ What should the ALB / Synthetics do if there's a wait timeout or lock timeout? I just rescued and returned 423 as a placeholder